### PR TITLE
Code cleanup in d3d11_x

### DIFF
--- a/dlls/d3d11_x/ID3D11ViewWrapper.cpp
+++ b/dlls/d3d11_x/ID3D11ViewWrapper.cpp
@@ -12,15 +12,14 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+
+        // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
+        
 
         return m_realTarget->QueryInterface(riid, ppvObject);
     }
@@ -87,15 +86,13 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+
+        // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
 
         return m_realTarget->QueryInterface(riid, ppvObject);
     }
@@ -162,15 +159,13 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+        
+         // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
 
         return m_realTarget->QueryInterface(riid, ppvObject);
     }
@@ -237,15 +232,13 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+
+        // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
 
         return m_realTarget->QueryInterface(riid, ppvObject);
     }

--- a/dlls/d3d11_x/IDXGIAdapterWrapper.cpp
+++ b/dlls/d3d11_x/IDXGIAdapterWrapper.cpp
@@ -15,15 +15,13 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+
+        // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
 
         return m_realAdapter->QueryInterface(riid, ppvObject);
     }

--- a/dlls/d3d11_x/IDXGIDeviceWrapper.cpp
+++ b/dlls/d3d11_x/IDXGIDeviceWrapper.cpp
@@ -12,15 +12,13 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+
+        // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
 
         return m_realDevice->QueryInterface(riid, ppvObject);
     }

--- a/dlls/d3d11_x/IDXGIFactoryWrapper.cpp
+++ b/dlls/d3d11_x/IDXGIFactoryWrapper.cpp
@@ -17,15 +17,13 @@ namespace d3d11x
 				AddRef( );
 				return S_OK;
 			}
-			else
-			{
-				// DEBUG
-				char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-				OLECHAR iidwstr[ sizeof(iidstr) ];
-				StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-				WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-				printf("[IDXGIFactoryWrapper] QueryInterface: %s\n", iidstr);
-			}
+
+			// DEBUG
+			char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+			OLECHAR iidwstr[ sizeof(iidstr) ];
+			StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+			WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+			printf("[IDXGIFactoryWrapper] QueryInterface: %s\n", iidstr);
 
 			
 			return m_realFactory->QueryInterface(riid, ppvObject);

--- a/dlls/d3d11_x/IDXGISwapChainWrapper.cpp
+++ b/dlls/d3d11_x/IDXGISwapChainWrapper.cpp
@@ -13,15 +13,13 @@ namespace d3d11x
             AddRef( );
             return S_OK;
         }
-        else
-        {
-            // DEBUG
-            char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
-            OLECHAR iidwstr[ sizeof(iidstr) ];
-            StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
-            WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
-            printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
-        }
+
+        // DEBUG
+        char iidstr[ sizeof("{AAAAAAAA-BBBB-CCCC-DDEE-FFGGHHIIJJKK}") ];
+        OLECHAR iidwstr[ sizeof(iidstr) ];
+        StringFromGUID2(riid, iidwstr, ARRAYSIZE(iidwstr));
+        WideCharToMultiByte(CP_UTF8, 0, iidwstr, -1, iidstr, sizeof(iidstr), nullptr, nullptr);
+        printf("[IDXGIDeviceWrapper] QueryInterface: %s\n", iidstr);
 
         return m_realSwapchain->QueryInterface(riid, ppvObject);
     }

--- a/dlls/d3d11_x/d3d_x/d3d11_x_device.cpp
+++ b/dlls/d3d11_x/d3d_x/d3d11_x_device.cpp
@@ -44,14 +44,7 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateTexture1D(
     ID3D11Texture1D* texture1d = nullptr;
     HRESULT hr = m_realDevice->CreateTexture1D(pDesc, pInitialData, &texture1d);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppTexture1D = new ID3D11Texture1DWrapper(texture1d);
-    }
-    else
-    {
-        *ppTexture1D = nullptr;
-    }
+    *ppTexture1D = SUCCEEDED(hr) ? new ID3D11Texture1DWrapper(texture1d) : nullptr;
 
     return hr;
 }
@@ -64,14 +57,8 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateTexture2D(
     ID3D11Texture2D* texture2d = nullptr;
     HRESULT hr = m_realDevice->CreateTexture2D(pDesc, pInitialData, &texture2d);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppTexture2D = new ID3D11Texture2DWrapper(texture2d);
-    }
-    else
-    {
-        *ppTexture2D = nullptr;
-    }
+    *ppTexture2D = SUCCEEDED(hr) ? new ID3D11Texture2DWrapper(texture2d) : nullptr;
+
 
     return hr;
 }
@@ -84,14 +71,8 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateTexture3D(
     ID3D11Texture3D* texture3d = nullptr;
     HRESULT hr = m_realDevice->CreateTexture3D(pDesc, pInitialData, &texture3d);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppTexture3D = new ID3D11Texture3DWrapper(texture3d);
-    }
-    else
-    {
-        *ppTexture3D = nullptr;
-    }
+    *ppTexture3D = SUCCEEDED(hr) ? new ID3D11Texture3DWrapper(texture3d) : nullptr;
+
 
     return hr;
 }
@@ -104,14 +85,8 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateShaderResourceView(
     ::ID3D11ShaderResourceView* target = nullptr;
     HRESULT hr = m_realDevice->CreateShaderResourceView(reinterpret_cast<ID3D11ResourceWrapperX*>(pResource)->m_realResource, pDesc, &target);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppSRView = reinterpret_cast<ID3D11ShaderResourceView_X*>(new ID3D11ShaderResourceViewWrapper(target));
-    }
-    else
-    {
-        *ppSRView = nullptr;
-    }
+    *ppSRView = SUCCEEDED(hr) ? reinterpret_cast<ID3D11ShaderResourceView_X*>(new ID3D11ShaderResourceViewWrapper(target))
+                              : nullptr;
 
     return hr;
 }
@@ -124,14 +99,8 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateUnorderedAccessView(
     ::ID3D11UnorderedAccessView* target = nullptr;
     HRESULT hr = m_realDevice->CreateUnorderedAccessView(reinterpret_cast<ID3D11ResourceWrapperX*>(pResource)->m_realResource, pDesc, &target);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppUAView = reinterpret_cast<ID3D11UnorderedAccessView_X*>(new ID3D11UnorderedAccessViewWrapper(target));
-    }
-    else
-    {
-        *ppUAView = nullptr;
-    }
+    *ppUAView = SUCCEEDED(hr) ? reinterpret_cast<ID3D11UnorderedAccessView_X*>(new ID3D11UnorderedAccessViewWrapper(target))
+                              : nullptr;
 
     return hr;
 }
@@ -144,14 +113,8 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateRenderTargetView(
     ::ID3D11RenderTargetView* target = nullptr;
     HRESULT hr = m_realDevice->CreateRenderTargetView(reinterpret_cast<ID3D11ResourceWrapperX*>(pResource)->m_realResource, pDesc, &target);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppRTView = reinterpret_cast<ID3D11RenderTargetView_X*>(new ID3D11RenderTargetViewWrapper(target));
-    }
-    else
-    {
-        *ppRTView = nullptr;
-    }
+    *ppRTView = SUCCEEDED(hr) ? reinterpret_cast<ID3D11RenderTargetView_X*>(new ID3D11RenderTargetViewWrapper(target))
+                              : nullptr;
 
     return hr;
 }
@@ -164,14 +127,9 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateDepthStencilView(
     ::ID3D11DepthStencilView* target = nullptr;
     HRESULT hr = m_realDevice->CreateDepthStencilView(reinterpret_cast<ID3D11ResourceWrapperX*>(pResource)->m_realResource, pDesc, &target);
 
-    if (SUCCEEDED(hr))
-    {
-        *ppDepthStencilView = reinterpret_cast<ID3D11DepthStencilView_X*>(new ID3D11DepthStencilViewWrapper(target));
-    }
-    else
-    {
-        *ppDepthStencilView = nullptr;
-    }
+    *ppDepthStencilView = SUCCEEDED(hr) ? reinterpret_cast<ID3D11DepthStencilView_X*>(new ID3D11DepthStencilViewWrapper(target))
+                                        : nullptr;
+
 
     return hr;
 }
@@ -181,13 +139,12 @@ void d3d11x::D3D11DeviceXWrapperX::GetImmediateContext(ID3D11DeviceContext** ppI
     ::ID3D11DeviceContext* ctx{};
     m_realDevice->GetImmediateContext(&ctx);
 
-    if(ctx)
-    {
-        ::ID3D11DeviceContext2* ctx2{};
-        ctx->QueryInterface(IID_PPV_ARGS(&ctx2));
+    if (!ctx) return;
 
-        *ppImmediateContext = reinterpret_cast<d3d11x::ID3D11DeviceContext*>(new d3d11x::ID3D11DeviceContextXWrapper(ctx2));
-    }
+    ::ID3D11DeviceContext2* ctx2{};
+    ctx->QueryInterface(IID_PPV_ARGS(&ctx2));
+
+    *ppImmediateContext = reinterpret_cast<d3d11x::ID3D11DeviceContext*>(new d3d11x::ID3D11DeviceContextXWrapper(ctx2));
 }
 
 HRESULT d3d11x::D3D11DeviceXWrapperX::CreateDeferredContext(UINT ContextFlags, d3d11x::ID3D11DeviceContext** ppDeferredContext)
@@ -216,14 +173,7 @@ HRESULT d3d11x::D3D11DeviceXWrapperX::CreateBuffer(
     ID3D11Buffer* buffer = nullptr;
     HRESULT hr = m_realDevice->CreateBuffer(pDesc, pInitialData, &buffer);
     
-    if (SUCCEEDED(hr))
-    {
-        *ppBuffer = new ID3D11BufferWrapper(buffer);
-    }
-    else
-    {
-        *ppBuffer = nullptr;
-    }
+    *ppBuffer = SUCCEEDED(hr) ? new ID3D11BufferWrapper(buffer) : nullptr;
 
     return hr;
 }

--- a/dlls/kernelx/kernelx.cpp
+++ b/dlls/kernelx/kernelx.cpp
@@ -83,6 +83,9 @@ BOOL TitleMemoryStatus_X(LPTITLEMEMORYSTATUS Buffer)
     //*(DWORD*)((uint8_t*)Buffer + 72) = ProcessInformation[8];
 
     // equivalent to the previous code
+    // TODO: Changes this code to not be pre-incremented before a deref.
+    //       i.e. Buffer++; Bufer->DwLength
+    //       Makes code look uglier but you won't get yelled at by 80 y/o
     (++Buffer)->dwLength = ProcessInformation[7];
     (++Buffer)->dwReserved = ProcessInformation[8];
 


### PR DESCRIPTION
Just a general code cleanup in the d3d11_x dll & kernelx from review in #93 

I need someone to please **test this** before it is merged as I have no way of testing it myself.

Code simplification:

* [`dlls/d3d11_x/ID3D11ViewWrapper.cpp`](diffhunk://#diff-5b8ab239a92853651e3a95ced483f45e79aac8218c12e7fca274213f22a3a4e4L15-R22): Removed unnecessary `else` blocks following `if` statements that return a value. [[1]](diffhunk://#diff-5b8ab239a92853651e3a95ced483f45e79aac8218c12e7fca274213f22a3a4e4L15-R22) [[2]](diffhunk://#diff-5b8ab239a92853651e3a95ced483f45e79aac8218c12e7fca274213f22a3a4e4L90-L98) [[3]](diffhunk://#diff-5b8ab239a92853651e3a95ced483f45e79aac8218c12e7fca274213f22a3a4e4L165-L173) [[4]](diffhunk://#diff-5b8ab239a92853651e3a95ced483f45e79aac8218c12e7fca274213f22a3a4e4L240-L248)
* [`dlls/d3d11_x/IDXGIAdapterWrapper.cpp`](diffhunk://#diff-246a5722166bf8cb77e23968eed0862a5564b832285309351e5f6b5e98fc2d39L18-L26): Removed unnecessary `else` block.
* [`dlls/d3d11_x/IDXGIDeviceWrapper.cpp`](diffhunk://#diff-ef1961a119aba6b6ab27becff187289ac490c3168873a59ca9a4de85c18b02d4L15-L23): Removed unnecessary `else` block.
* [`dlls/d3d11_x/IDXGIFactoryWrapper.cpp`](diffhunk://#diff-da7fbf5cdce85278af747e828b21ca15bbf16724906fda8afa4c9ee65659c0b1L20-L28): Removed unnecessary `else` block.
* [`dlls/d3d11_x/IDXGISwapChainWrapper.cpp`](diffhunk://#diff-169b30d48df85f1c12b91e22f4b5c8f9af774c497aaddeb98cdf1751e513bbb4L16-L24): Removed unnecessary `else` block.

Use of ternary operators for conditional assignments:

* [`dlls/d3d11_x/d3d_x/d3d11_x_device.cpp`](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L47-R47): Converted conditional assignments to use ternary operators in multiple functions, including `CreateTexture1D`, `CreateTexture2D`, `CreateTexture3D`, `CreateShaderResourceView`, `CreateUnorderedAccessView`, `CreateRenderTargetView`, `CreateDepthStencilView`, and `CreateBuffer`. [[1]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L47-R47) [[2]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L67-R61) [[3]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L87-R75) [[4]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L107-R89) [[5]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L127-R103) [[6]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L147-R117) [[7]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L167-R132) [[8]](diffhunk://#diff-f37f937ea0b9fe9d3c03e46a27dea15dff3bfb8790f56cff0019dd4fed3d72f5L219-R176)

Comments for potential improvements:

* [`dlls/d3d11_x/d3d11_x.cpp`](diffhunk://#diff-1b17d7f66b612a2055bccb2227c7673338e3d3bda4c5fb5709bdf38503884207R171): Added a comment suggesting a potential check for the validity of `ppDevice` before dereferencing it.
* [`dlls/kernelx/kernelx.cpp`](diffhunk://#diff-d7aba761f0ef25b2a5fc338f4c27685c6004270820658aca705600b4d5ecc711R86-R88): Added a comment suggesting changes to avoid pre-increment before dereferencing to improve code readability.

Refactoring switch statements:

* [`dlls/d3d11_x/d3d11_x.cpp`](diffhunk://#diff-1b17d7f66b612a2055bccb2227c7673338e3d3bda4c5fb5709bdf38503884207L56-R73): Refactored `if-else` statements into a `switch` statement for handling `Flags` in `D3DAllocateGraphicsMemory_X`.